### PR TITLE
Migrate static_graph callsite

### DIFF
--- a/torchrec/distributed/model_parallel.py
+++ b/torchrec/distributed/model_parallel.py
@@ -92,12 +92,9 @@ class DefaultDataParallelWrapper(DataParallelWrapper):
                 process_group=pg,
                 gradient_as_bucket_view=True,
                 broadcast_buffers=False,
+                static_graph=True,
             ),
         )
-
-        # Enable static graph for better DPP performance
-        # pyre-ignore
-        dmp.module._set_static_graph()
 
 
 class DistributedModelParallel(nn.Module, FusedOptimizerModule):


### PR DESCRIPTION
Summary:
Static graph is now part of DDP constructor, so migrate the callsite away from the private API which will eventually be deprecated.

Question regarding OSS side: Since this is dependent on a recently landed pytorch change, do we need to gate this code based on PT version or does TRec use latest pytorch?

Differential Revision: D34045294

