### PR TITLE
Fix the TorchRec BC issue from fbgemm_gpu::permute_2D_sparse_data

### DIFF
--- a/torchrec/distributed/comm_ops.py
+++ b/torchrec/distributed/comm_ops.py
@@ -617,7 +617,7 @@ class All2All_Seq_Req(Function):
                     permuted_lengths_after_sparse_data_all2all,
                     sharded_input_embeddings,
                     _,
-                ) = torch.ops.fbgemm.permute_2D_sparse_data(
+                ) = torch.ops.fbgemm.permute_sparse_data(
                     forward_recat_tensor,
                     lengths_after_sparse_data_all2all.view(local_T * world_size, -1),
                     sharded_input_embeddings.view(-1),
@@ -674,7 +674,7 @@ class All2All_Seq_Req(Function):
 
         if permuted_lengths_after_sparse_data_all2all is not None:
             with record_function("## alltoall_seq_embedding_bwd_permute ##"):
-                _, sharded_grad_input, _ = torch.ops.fbgemm.permute_2D_sparse_data(
+                _, sharded_grad_input, _ = torch.ops.fbgemm.permute_sparse_data(
                     backward_recat_tensor,
                     permuted_lengths_after_sparse_data_all2all,
                     sharded_grad_input,

--- a/torchrec/distributed/dist_data.py
+++ b/torchrec/distributed/dist_data.py
@@ -196,7 +196,7 @@ class KJTAllToAllIndicesAwaitable(Awaitable[KeyedJaggedTensor]):
 
         with record_function("## all2all_data:recat_values ##"):
             if self._recat.numel():
-                lengths, values, weights = torch.ops.fbgemm.permute_2D_sparse_data(
+                lengths, values, weights = torch.ops.fbgemm.permute_sparse_data(
                     self._recat,
                     lengths.view(self._workers * self._splits[self._pg.rank()], -1),
                     values,

--- a/torchrec/sparse/jagged_tensor.py
+++ b/torchrec/sparse/jagged_tensor.py
@@ -742,7 +742,7 @@ class KeyedJaggedTensor(Pipelineable, metaclass=JaggedTensorMeta):
             permuted_lengths,
             permuted_values,
             permuted_weights,
-        ) = torch.ops.fbgemm.permute_2D_sparse_data(
+        ) = torch.ops.fbgemm.permute_sparse_data(
             indices_tensor,
             self.lengths().view(len(self._keys), -1),
             self.values(),


### PR DESCRIPTION
Summary: D34333459 (https://github.com/facebookresearch/torchrec/commit/eefc6d4a6241d6c764c5386ee67fa9a384ee6cc9) caused the BC issues for FBGEMM_GPU ops to TorchRec. This Diff intends to add back the corresponding permute_sparse_data_cuda and permute_sparse_data_cpu functions and resolve the BC issue. We will slowly deprecate the old version.

Reviewed By: hlin09

Differential Revision: D34392461

